### PR TITLE
Prefix command `goto-previous-buffer` and add example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ that very quickly.
 You will need to add a keyboard shortcut to execute the `goto-previous-buffer` command. I recommend assigning it to `shift+tab` or `ctrl-shift+tab` (I know
 that these keyboards are already assigned to move the indentation left or cycle to the other open buffers but I use that thing all the time so I recommend assigning it to an easy combination). You can also use `ctrl+6` like vim! To do that press `ctrl+shift+p` and then search for `open keyboard shortcuts`. In the filter in this write `goto-previous-buffer` and then click the cross or pencil to change the shortcut to your desired one.
 
+Example JSON keybindings configuration:
+
+```json
+[
+    {
+        "key": "shift+tab",
+        "command": "goto-previous-buffer.goto-previous-buffer",
+    }
+]
+```
+
 ## Known Issues
 
 None that I know of. This probably won't work when the previous thing you visited was not a real file :)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ that very quickly.
 ## Extension Settings
 
 You will need to add a keyboard shortcut to execute the `goto-previous-buffer` command. I recommend assigning it to `shift+tab` or `ctrl-shift+tab` (I know
-that these keyboards are already assigned to move the indentation left or cycle to the other open buffers but I use that thing all the time so I recommend assigning it to an easy combination). You can also use `ctrl+6` like vim! To do that press `ctrl+shift+p` and then search for `open keyboard shortcuts`. In the filter in this write write `goto-previous-buffer` and then click the cross or pencil to change the shortcut to your desired one.
+that these keyboards are already assigned to move the indentation left or cycle to the other open buffers but I use that thing all the time so I recommend assigning it to an easy combination). You can also use `ctrl+6` like vim! To do that press `ctrl+shift+p` and then search for `open keyboard shortcuts`. In the filter in this write `goto-previous-buffer` and then click the cross or pencil to change the shortcut to your desired one.
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	"contributes": {
 		"commands": [
 			{
-				"command": "extension.goto-previous-buffer",
+				"command": "goto-previous-buffer.goto-previous-buffer",
 				"title": "Goto previous buffer"
 			}
 		]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 export function activate(context: vscode.ExtensionContext) {
 	console.log('goto-previous-buffer: The extension "goto-previous-buffer" is now active!');
 
-	let disposable = vscode.commands.registerCommand('extension.goto-previous-buffer', () => {
+	let disposable = vscode.commands.registerCommand('goto-previous-buffer.goto-previous-buffer', () => {
 		var pate = context.workspaceState.get("PREVIOUS_ACTIVE_TEXT_EDITOR") as vscode.TextEditor;
 		
 		if(pate) {


### PR DESCRIPTION
At the moment, the command is `extension.goto-previous-buffer`, which made finding the command a bit more difficult. I think changing the command name to be `goto-previous-buffer.goto-previous-buffer` instead makes more sense.

This pull request also adds some example keybindings to the README. I think this is more important than renaming the command, as it means one less click to find out the name of the command.